### PR TITLE
Slide fix for all screen sizes

### DIFF
--- a/lib/custom_drawer_guitar.dart
+++ b/lib/custom_drawer_guitar.dart
@@ -61,8 +61,10 @@ class CustomGuitarDrawerState extends State<CustomGuitarDrawer>
                       ..setEntry(3, 2, 0.001)
                       ..rotateY(math.pi / 2 * (1 - animationController.value)),
                     alignment: Alignment.centerRight,
-                    child: MyDrawer(),
-                  ),
+                    child: Container(
+                        width: maxSlide ,
+                        child: MyDrawer()),
+                    ),
                 ),
                 Transform.translate(
                   offset: Offset(maxSlide * animationController.value, 0),


### PR DESCRIPTION
On android nexus 5 the animation was not working as it suppose to . So adding this worked for me